### PR TITLE
Save button must be green when the "New Game" button is pressed

### DIFF
--- a/GoalieStatsTracker/Views/RecordStatsView.swift
+++ b/GoalieStatsTracker/Views/RecordStatsView.swift
@@ -24,7 +24,7 @@ struct RecordStatsView: View {
     static let colorNeutral = Color.gray
     
     @State private var colorGoalButton : Color = colorNeutral
-    @State private var colorSaveButton : Color = colorNeutral
+    @State private var colorSaveButton : Color = colorSave
     @State private var color8MGoalButton : Color = colorNeutral
     @State private var color8MSaveButton : Color = colorNeutral
     


### PR DESCRIPTION
Since isGoal and is8Meter state variables are both false, it means the first click wil be a save. So, the color of the save button must be green instead of gray when the app first starts.