### PR TITLE
Fix the problem with Track-Your-Stats title floating up to the top

### DIFF
--- a/GoalieStatsTracker/Views/ContentView.swift
+++ b/GoalieStatsTracker/Views/ContentView.swift
@@ -74,10 +74,6 @@ struct ContentView: View {
                         Spacer()
                     }
                     .frame(maxWidth: .infinity, alignment: .trailing)
-
-                    Spacer()
-                        .frame(width: 40)
-
                 }
             }
             .navigationViewStyle(.stack)


### PR DESCRIPTION
<img width="768" alt="image" src="https://github.com/SanyaArora2007/GoalieStatsTracker/assets/5897977/a075aa5f-deaa-4f7e-b7b9-0c6c4c507059">
