### PR TITLE
Fix bug with past games getting deleted, and added option to resume an interrupted game.

### DIFF
--- a/GoalieStatsTracker/GameStore.swift
+++ b/GoalieStatsTracker/GameStore.swift
@@ -34,10 +34,13 @@ class GameStore: ObservableObject {
         let games = try await task.value
         return games
     }
-    
+
     func save(game: ShotsData) async throws {
         let task = Task {
             try await discardOngoingGame()
+            if game.gameName.trimmingCharacters(in: .whitespaces).count == 0 {
+                game.gameName = "My Game"
+            }
             storage.insert(game, at: 0)
             let data = try JSONEncoder().encode(storage)
             let outfile = try GameStore.fileURL()

--- a/GoalieStatsTracker/GameStore.swift
+++ b/GoalieStatsTracker/GameStore.swift
@@ -53,8 +53,8 @@ class GameStore: ObservableObject {
             try data.write(to: outfile)
         }
         _  = try await task.value
-    }
-    
+    }				
+
     func discardOngoingGame()  async throws {
         let task = Task {
             do {
@@ -63,7 +63,7 @@ class GameStore: ObservableObject {
         }
         _  = await task.value
     }
-    
+
     func remove(offsets: IndexSet) async throws {
         let task = Task {
             storage.remove(atOffsets: offsets)

--- a/GoalieStatsTracker/ShotsData.swift
+++ b/GoalieStatsTracker/ShotsData.swift
@@ -44,9 +44,6 @@ class ShotsData: ObservableObject, Codable, Identifiable, Hashable {
     
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-        if gameName.trimmingCharacters(in: .whitespaces).count == 0 {
-            gameName = "My Game"
-        }
         try container.encode(runningScore, forKey: .runningScore)
         try container.encode(totalShots, forKey: .totalShots)
         try container.encode(saves, forKey: .saves)

--- a/GoalieStatsTracker/Views/ContentView.swift
+++ b/GoalieStatsTracker/Views/ContentView.swift
@@ -77,6 +77,12 @@ struct ContentView: View {
                 }
             }
             .navigationViewStyle(.stack)
+            .task {
+                do {
+                    let _ = try await gameStore.load()
+                }
+                catch {}
+            }
         }
     }
 }

--- a/GoalieStatsTracker/Views/ContentView.swift
+++ b/GoalieStatsTracker/Views/ContentView.swift
@@ -14,7 +14,7 @@ struct ContentView: View {
     let buttonFontSize: CGFloat = 0.03
     let buttonBorderWidth: CGFloat = 0.004
     let buttonWidth: CGFloat = 0.35
-    let buttonHeight: CGFloat = 0.075
+    let buttonHeight: CGFloat = 0.09
     let buttonRadiusSize: CGFloat = 0.02
     let titleSize: CGFloat = 0.05
     let mainImageSize: CGFloat = 0.70
@@ -46,7 +46,7 @@ struct ContentView: View {
                         NavigationLink {
                             RecordStatsView(gameStore: _gameStore)
                         } label: {
-                            Text("New Game")
+                            Text(gameStore.ongoingGame == nil ? "New\nGame" : "Resume\nGame")
                                 .foregroundStyle(.teal)
                                 .font(.system(size: proxy.size.height * buttonFontSize))
                                 .overlay(
@@ -61,7 +61,7 @@ struct ContentView: View {
                         NavigationLink {
                             LoadPastView()
                         } label: {
-                            Text("Load Past")
+                            Text("Load Past\nGames")
                                 .foregroundStyle(.teal)
                                 .font(.system(size: proxy.size.height * buttonFontSize))
                                 .overlay(

--- a/GoalieStatsTracker/Views/FieldView.swift
+++ b/GoalieStatsTracker/Views/FieldView.swift
@@ -26,6 +26,14 @@ struct FieldView: View {
                 let shot = _parent.shotsData.newShot(goal:_parent.isGoal, eightMeter:_parent.is8Meter, location:event.location)
                 if shot != nil {
                     _parent.pointsOn12Meter.append(shot!)
+                    Task {
+                        do {
+                            try await _parent.gameStore.saveOngoingGame(game: _parent.shotsData)
+                        }
+                        catch {
+                            fatalError(error.localizedDescription)
+                        }
+                    }
                 }
             }
     }

--- a/GoalieStatsTracker/Views/FieldView.swift
+++ b/GoalieStatsTracker/Views/FieldView.swift
@@ -31,7 +31,7 @@ struct FieldView: View {
                             try await _parent.gameStore.saveOngoingGame(game: _parent.shotsData)
                         }
                         catch {
-                            fatalError(error.localizedDescription)
+                            // don't report any errors because it will cause the app to crash in the middle of the game
                         }
                     }
                 }

--- a/GoalieStatsTracker/Views/GameButtonsView.swift
+++ b/GoalieStatsTracker/Views/GameButtonsView.swift
@@ -73,6 +73,14 @@ struct GameButtonsView: View {
                 Button(
                     action: {
                         showDiscardAlert = true
+                        Task {
+                            do {
+                                try await discard()
+                            }
+                            catch {
+                                fatalError(error.localizedDescription)
+                            }
+                        }
                     },
                     label: {
                         Text("Discard")
@@ -109,4 +117,12 @@ struct GameButtonsView: View {
         }
     }
     
+    func discard() async throws {
+        do {
+            try await _parent.gameStore.discardOngoingGame()
+        }
+        catch {
+            fatalError(error.localizedDescription)
+        }
+    }
 }

--- a/GoalieStatsTracker/Views/GameButtonsView.swift
+++ b/GoalieStatsTracker/Views/GameButtonsView.swift
@@ -74,12 +74,7 @@ struct GameButtonsView: View {
                     action: {
                         showDiscardAlert = true
                         Task {
-                            do {
-                                try await discard()
-                            }
-                            catch {
-                                fatalError(error.localizedDescription)
-                            }
+                            await discard()
                         }
                     },
                     label: {
@@ -117,12 +112,12 @@ struct GameButtonsView: View {
         }
     }
     
-    func discard() async throws {
+    func discard() async {
         do {
             try await _parent.gameStore.discardOngoingGame()
         }
         catch {
-            fatalError(error.localizedDescription)
+            // no need to report any errors when discarding a game
         }
     }
 }

--- a/GoalieStatsTracker/Views/GameButtonsView.swift
+++ b/GoalieStatsTracker/Views/GameButtonsView.swift
@@ -56,11 +56,15 @@ struct GameButtonsView: View {
                                         .frame(width: _geometry.size.width * buttonWidth, height: _geometry.size.height * buttonHeight)
                                 )
                                 .alert(isPresented: $showSaveAlert) {
-                                    Alert(title: Text("Game had been saved!"), message: Text("Go to Load Past to view your stats"), dismissButton: Alert.Button.default(
-                                        Text("Main Menu"), action: {
-                                            presentationMode.wrappedValue.dismiss()
-                                        }
-                                    )
+                                    Alert(
+                                        title: Text("Game had been saved!"),
+                                        message: Text("Go to Load Past to view your stats"),
+                                        dismissButton: Alert.Button.default(
+                                            Text("Main Menu"),
+                                            action: {
+                                                presentationMode.wrappedValue.dismiss()
+                                            }
+                                        )
                                     )
                                 }
                         }

--- a/GoalieStatsTracker/Views/LoadPastView.swift
+++ b/GoalieStatsTracker/Views/LoadPastView.swift
@@ -28,7 +28,7 @@ struct LoadPastView: View {
                     ForEach(games, id: \.self) { game in
                         VStack(alignment: .leading) {
                             NavigationLink {
-                                RecordStatsView(gameStore: _gameStore, shotsData: game)
+                                RecordStatsView(gameStore: _gameStore, shotsData: game, loadPast: true)
                             } label: {
                                 VStack {
                                     Text(game.gameName)

--- a/GoalieStatsTracker/Views/LoadPastView.swift
+++ b/GoalieStatsTracker/Views/LoadPastView.swift
@@ -28,7 +28,7 @@ struct LoadPastView: View {
                     ForEach(games, id: \.self) { game in
                         VStack(alignment: .leading) {
                             NavigationLink {
-                                RecordStatsView(gameStore: _gameStore, shotsData: game, loadPast: true)
+                                RecordStatsView(gameStore: _gameStore, shotsData: game)
                             } label: {
                                 VStack {
                                     Text(game.gameName)

--- a/GoalieStatsTracker/Views/RecordStatsView.swift
+++ b/GoalieStatsTracker/Views/RecordStatsView.swift
@@ -31,12 +31,12 @@ struct RecordStatsView: View {
         _gameStore = gameStore
     }
     
-    init(gameStore: EnvironmentObject<GameStore>, shotsData: ShotsData) {
+    init(gameStore: EnvironmentObject<GameStore>, shotsData: ShotsData, loadPast: Bool) {
         _gameStore = gameStore
         _shotsData = StateObject(wrappedValue: shotsData)
         _pointsOn12Meter = State(initialValue: shotsData.shots)
-        loadPastView = true
-        disable = true
+        loadPastView = loadPast
+        disable = loadPast
     }
     
     var body: some View {

--- a/GoalieStatsTracker/Views/RecordStatsView.swift
+++ b/GoalieStatsTracker/Views/RecordStatsView.swift
@@ -21,22 +21,26 @@ struct RecordStatsView: View {
     @State var isGoal: Bool = false
     @State var is8Meter: Bool = false
             
-    @StateObject var shotsData = ShotsData()
+    @State var shotsData = ShotsData()
 
-    
     init() {
     }
 
     init(gameStore: EnvironmentObject<GameStore>) {
         _gameStore = gameStore
+        let ongoingGame = self.gameStore.ongoingGame
+        if ongoingGame != nil {
+            self._shotsData = State(initialValue: ongoingGame!)
+            self._pointsOn12Meter = State(initialValue: ongoingGame!.shots)
+        }
     }
     
-    init(gameStore: EnvironmentObject<GameStore>, shotsData: ShotsData, loadPast: Bool) {
+    init(gameStore: EnvironmentObject<GameStore>, shotsData: ShotsData) {
         _gameStore = gameStore
-        _shotsData = StateObject(wrappedValue: shotsData)
+        _shotsData = State(initialValue: shotsData)
         _pointsOn12Meter = State(initialValue: shotsData.shots)
-        loadPastView = loadPast
-        disable = loadPast
+        loadPastView = true
+        disable = true
     }
     
     var body: some View {


### PR DESCRIPTION
Main menu now shows buttons with two rows of text:
<img width="200" alt="image" src="https://github.com/SanyaArora2007/GoalieStatsTracker/assets/5897977/adb11834-2f74-40e1-8f63-7d477feb8ca9">

And if a game is interrupted and the app starts again, the "New Game" button now shows "Resume Game".
<img width="200" alt="image" src="https://github.com/SanyaArora2007/GoalieStatsTracker/assets/5897977/500075b1-49c4-4926-a609-12574dc73c13">
