### PR TITLE
Add seasons for organizing saved games

### DIFF
--- a/GoalieStatsTracker.xcodeproj/project.pbxproj
+++ b/GoalieStatsTracker.xcodeproj/project.pbxproj
@@ -26,6 +26,8 @@
 		03E507C12AC6795000134DD0 /* GoalieStatsTrackerUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E507C02AC6795000134DD0 /* GoalieStatsTrackerUITests.swift */; };
 		03E507C32AC6795000134DD0 /* GoalieStatsTrackerUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E507C22AC6795000134DD0 /* GoalieStatsTrackerUITestsLaunchTests.swift */; };
 		7EA062F02FCC9B9300C1332E /* GoalieSelectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EA062EF2FCC9B9300C1332E /* GoalieSelectorView.swift */; };
+		7EA062F22FCC9B9300C1332E /* SaveGamePopupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EA062F12FCC9B9300C1332E /* SaveGamePopupView.swift */; };
+		7EA062F42FCC9B9300C1332E /* SeasonsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EA062F32FCC9B9300C1332E /* SeasonsView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -68,6 +70,8 @@
 		03E507C02AC6795000134DD0 /* GoalieStatsTrackerUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalieStatsTrackerUITests.swift; sourceTree = "<group>"; };
 		03E507C22AC6795000134DD0 /* GoalieStatsTrackerUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalieStatsTrackerUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		7EA062EF2FCC9B9300C1332E /* GoalieSelectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalieSelectorView.swift; sourceTree = "<group>"; };
+		7EA062F12FCC9B9300C1332E /* SaveGamePopupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SaveGamePopupView.swift; sourceTree = "<group>"; };
+		7EA062F32FCC9B9300C1332E /* SeasonsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeasonsView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -109,6 +113,8 @@
 				034585FA2B56FEFC00528EC3 /* ScoringView.swift */,
 				034585FC2B57005700528EC3 /* GameButtonsView.swift */,
 				034585FE2B57042B00528EC3 /* GameTitleView.swift */,
+				7EA062F12FCC9B9300C1332E /* SaveGamePopupView.swift */,
+				7EA062F32FCC9B9300C1332E /* SeasonsView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -311,6 +317,8 @@
 				03E507A62AC6794F00134DD0 /* GoalieStatsTrackerApp.swift in Sources */,
 				034585FB2B56FEFC00528EC3 /* ScoringView.swift in Sources */,
 				034585FD2B57005700528EC3 /* GameButtonsView.swift in Sources */,
+				7EA062F22FCC9B9300C1332E /* SaveGamePopupView.swift in Sources */,
+				7EA062F42FCC9B9300C1332E /* SeasonsView.swift in Sources */,
 				034585FF2B57042B00528EC3 /* GameTitleView.swift in Sources */,
 				030670E42AFF0BC9007F82EF /* GameStore.swift in Sources */,
 				034585F12B56407800528EC3 /* ShotSelectorsView.swift in Sources */,

--- a/GoalieStatsTracker/GameStore.swift
+++ b/GoalieStatsTracker/GameStore.swift
@@ -12,6 +12,17 @@ import SwiftUI
 class GameStore: ObservableObject {
     @Published var storage: [ShotsData] = []
     @Published var ongoingGame: ShotsData? = nil
+
+    var seasons: [String] {
+        var result: [String] = []
+        for game in storage {
+            let name = game.seasonName
+            if name.isEmpty == false && result.contains(name) == false {
+                result.append(name)
+            }
+        }
+        return result
+    }
     
     private static func fileURL() throws -> URL {
         try FileManager.default.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: false)
@@ -94,6 +105,21 @@ class GameStore: ObservableObject {
             } catch {}
         }
         _  = await task.value
+    }
+
+    func removeSeason(named seasonName: String) async throws {
+        let task = Task {
+            objectWillChange.send()
+            for game in storage {
+                if game.seasonName == seasonName {
+                    game.seasonName = ""
+                }
+            }
+            let data = try JSONEncoder().encode(storage)
+            let outfile = try GameStore.fileURL()
+            try data.write(to: outfile)
+        }
+        _ = try await task.value
     }
 
     func remove(offsets: IndexSet) async throws {

--- a/GoalieStatsTracker/ShotsData.swift
+++ b/GoalieStatsTracker/ShotsData.swift
@@ -34,7 +34,8 @@ class ShotsData: ObservableObject, Codable, Identifiable, Hashable {
     @Published var gameTime: TimeInterval
     @Published var womensField: Bool = true
     @Published var goalies: [String] = [ShotsData.defaultGoalieName]
-    
+    @Published var seasonName: String = ""
+
     func hash(into hasher: inout Hasher) {
         hasher.combine(gameTime)
     }
@@ -45,7 +46,7 @@ class ShotsData: ObservableObject, Codable, Identifiable, Hashable {
     }
     
     enum CodingKeys: CodingKey {
-        case runningScore, totalShots, saves, savePercentage, shots, gameName, gameTime, womensField, goalies
+        case runningScore, totalShots, saves, savePercentage, shots, gameName, gameTime, womensField, goalies, seasonName
     }
     
     func encode(to encoder: Encoder) throws {
@@ -59,6 +60,7 @@ class ShotsData: ObservableObject, Codable, Identifiable, Hashable {
         try container.encode(gameTime, forKey: .gameTime)
         try container.encode(womensField, forKey: .womensField)
         try container.encode(goalies, forKey: .goalies)
+        try container.encode(seasonName, forKey: .seasonName)
     }
     
     required init(from decoder: Decoder) throws {
@@ -78,6 +80,7 @@ class ShotsData: ObservableObject, Codable, Identifiable, Hashable {
             womensField = true
         }
         goalies = (try? container.decode([String].self, forKey: .goalies)) ?? [ShotsData.defaultGoalieName]
+        seasonName = (try? container.decode(String.self, forKey: .seasonName)) ?? ""
     }
     
     required init() {

--- a/GoalieStatsTracker/Views/ContentView.swift
+++ b/GoalieStatsTracker/Views/ContentView.swift
@@ -89,9 +89,9 @@ struct ContentView: View {
                         .frame(height: proxy.size.height * verticalSpacerSize)
 
                     NavigationLink {
-                        LoadPastView()
+                        SeasonsView()
                     } label: {
-                        Text("Load Past Games")
+                        Text("Seasons")
                             .foregroundStyle(.teal)
                             .font(.system(size: proxy.size.height * buttonFontSize))
                             .overlay(

--- a/GoalieStatsTracker/Views/GameButtonsView.swift
+++ b/GoalieStatsTracker/Views/GameButtonsView.swift
@@ -12,7 +12,6 @@ struct GameButtonsView: View {
     
     @Environment(\.presentationMode) var presentationMode
     
-    @State private var showSaveAlert = false
     @State private var showDiscardAlert = false
         
     var _parent: RecordStatsView
@@ -35,15 +34,7 @@ struct GameButtonsView: View {
             HStack(alignment: .center) {
                 Button(
                     action: {
-                        showSaveAlert = true
-                        Task {
-                            do {
-                                try await save()
-                            }
-                            catch {
-                                fatalError(error.localizedDescription)
-                            }
-                        }
+                        _parent.showSavePopup = true
                     },
                     label: {
                         ZStack {
@@ -55,18 +46,6 @@ struct GameButtonsView: View {
                                         .stroke(Color.gray, lineWidth: _geometry.size.height * buttonBorderWidth)
                                         .frame(width: _geometry.size.width * buttonWidth, height: _geometry.size.height * buttonHeight)
                                 )
-                                .alert(isPresented: $showSaveAlert) {
-                                    Alert(
-                                        title: Text("Game had been saved!"),
-                                        message: Text("Go to Load Past to view your stats"),
-                                        dismissButton: Alert.Button.default(
-                                            Text("Main Menu"),
-                                            action: {
-                                                presentationMode.wrappedValue.dismiss()
-                                            }
-                                        )
-                                    )
-                                }
                         }
                     }
                 )
@@ -105,15 +84,6 @@ struct GameButtonsView: View {
             }
         }
 
-    }
-    
-    func save() async throws {
-        do {
-            try await _parent.gameStore.save(game: _parent.shotsData)
-        }
-        catch {
-            fatalError(error.localizedDescription)
-        }
     }
     
     func discard() async {

--- a/GoalieStatsTracker/Views/GameTitleView.swift
+++ b/GoalieStatsTracker/Views/GameTitleView.swift
@@ -71,6 +71,16 @@ struct GameTitleView: View {
                     .multilineTextAlignment(.center)
                     .font(.system(size: _geometry.size.height * 0.02, weight: .light))
                     .foregroundStyle(Color.black)
+
+                if _parent.shotsData.seasonName.isEmpty == false {
+                    Spacer()
+                        .frame(height: _geometry.size.height * 0.01)
+
+                    Text(_parent.shotsData.seasonName)
+                        .multilineTextAlignment(.center)
+                        .font(.system(size: _geometry.size.height * 0.02, weight: .light))
+                        .foregroundStyle(Color.black)
+                }
             }
         }
         else

--- a/GoalieStatsTracker/Views/LoadPastView.swift
+++ b/GoalieStatsTracker/Views/LoadPastView.swift
@@ -9,60 +9,94 @@ import SwiftUI
 
 struct LoadPastView: View {
     @EnvironmentObject var gameStore: GameStore
-    
+
+    @Environment(\.presentationMode) var presentationMode
+
     @State private var games: [ShotsData] = []
-    
+
+    @State private var popToSeasonsView: Bool = false
+
+    private var seasonName: String? = nil
+
     private var dateFormat: DateFormatter = DateFormatter()
-    
+
     init() {
         self.dateFormat.dateStyle = .long
-        self.dateFormat.timeStyle = .short
+        self.dateFormat.timeStyle = .none
+    }
+
+    init(seasonName: String) {
+        self.init()
+        self.seasonName = seasonName
+    }
+
+    private var title: String {
+        guard let seasonName = seasonName else {
+            return "Games"
+        }
+        return seasonName.isEmpty ? "No Season" : seasonName
     }
     
     // https://www.hackingwithswift.com/quick-start/swiftui/how-to-run-an-asynchronous-task-when-a-view-is-shown
     
     var body: some View {
         GeometryReader { proxy in
-            NavigationStack {
-                List {
-                    ForEach(games, id: \.self) { game in
-                        VStack(alignment: .leading) {
-                            NavigationLink {
-                                RecordStatsView(gameStore: _gameStore, shotsData: game)
-                            } label: {
-                                HStack {
-                                    Image(game.womensField == true ? "WomanRunning" : "ManRunning")
-                                        .resizable()
-                                        .scaledToFit()
-                                        .frame(width: proxy.size.width * 0.1)
-                                    VStack {
-                                        Text(game.gameName)
-                                            .frame(maxWidth: .infinity, alignment: .leading)
-                                            .font(.system(size: proxy.size.height * 0.02, weight: .semibold))
-                                        Spacer()
-                                            .frame(height: proxy.size.height * 0.0075)
-                                        Text(dateFormat.string(from: Date(timeIntervalSince1970:game.gameTime)))
-                                            .frame(maxWidth: .infinity, alignment: .leading)
-                                            .font(.system(size: proxy.size.height * 0.015, weight: .light))
-                                    }
+            List {
+                ForEach(games, id: \.self) { game in
+                    VStack(alignment: .leading) {
+                        NavigationLink {
+                            RecordStatsView(gameStore: _gameStore, shotsData: game, popToSeasonsView: $popToSeasonsView)
+                        } label: {
+                            HStack {
+                                Image(game.womensField == true ? "WomanRunning" : "ManRunning")
+                                    .resizable()
+                                    .scaledToFit()
+                                    .frame(width: proxy.size.width * 0.1)
+                                VStack {
+                                    Text(game.gameName)
+                                        .frame(maxWidth: .infinity, alignment: .leading)
+                                        .font(.system(size: proxy.size.height * 0.02, weight: .semibold))
+                                    Spacer()
+                                        .frame(height: proxy.size.height * 0.0075)
+                                    Text(dateFormat.string(from: Date(timeIntervalSince1970:game.gameTime)))
+                                        .frame(maxWidth: .infinity, alignment: .leading)
+                                        .font(.system(size: proxy.size.height * 0.015, weight: .light))
+                                    Spacer()
+                                        .frame(height: proxy.size.height * 0.0075)
+                                    Text(game.goalies.joined(separator: ", "))
+                                        .frame(maxWidth: .infinity, alignment: .leading)
+                                        .font(.system(size: proxy.size.height * 0.015, weight: .light))
                                 }
                             }
-                            Divider()
                         }
-                        .listRowSeparator(.hidden)
+                        Divider()
                     }
-                    .onDelete { indexes in
-                        Task {
-                            await deleteGame(offsets: indexes)
-                        }
+                    .listRowSeparator(.hidden)
+                }
+                .onDelete { indexes in
+                    Task {
+                        await deleteGame(offsets: indexes)
                     }
                 }
-                .navigationTitle("Games")
-                
+            }
+            .navigationTitle(title)
+            .onAppear {
+                if popToSeasonsView == true {
+                    popToSeasonsView = false
+                    // wait for the pop animation from RecordStatsView to finish
+                    // before popping again, or the second dismiss is ignored
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+                        presentationMode.wrappedValue.dismiss()
+                    }
+                }
             }
             .task {
                 do {
-                    try await games = gameStore.load()
+                    var loaded = try await gameStore.load()
+                    if let seasonName = seasonName {
+                        loaded = loaded.filter { $0.seasonName == seasonName }
+                    }
+                    games = loaded
                 }
                 catch {
                     fatalError(error.localizedDescription)
@@ -73,8 +107,14 @@ struct LoadPastView: View {
     
     func deleteGame(offsets: IndexSet) async {
         do {
+            let gamesToDelete = offsets.map { games[$0] }
             games.remove(atOffsets: offsets)
-            try await gameStore.remove(offsets: offsets)
+            let storageOffsets = IndexSet(
+                gameStore.storage.enumerated()
+                    .filter { gamesToDelete.contains($0.element) }
+                    .map { $0.offset }
+            )
+            try await gameStore.remove(offsets: storageOffsets)
         }
         catch {
             fatalError(error.localizedDescription)

--- a/GoalieStatsTracker/Views/RecordStatsView.swift
+++ b/GoalieStatsTracker/Views/RecordStatsView.swift
@@ -11,10 +11,19 @@ struct RecordStatsView: View {
     
     var loadPastView: Bool = false
     var disable: Bool = false
+    var popToSeasonsView: Binding<Bool>? = nil
     
     @EnvironmentObject var gameStore: GameStore
-    
+
+    @Environment(\.presentationMode) var presentationMode
+
     @State private var runningScoreColor: Color = Color.black
+
+    @State var showSavePopup: Bool = false
+
+    // shotsData is a class held in @State, so mutating its seasonName alone
+    // does not re-render this view; this gets toggled to force the refresh
+    @State private var seasonAssignmentRefresh: Bool = false
     
     @State var pointsOn12Meter: [ShotsData.Shot] = []
 
@@ -39,36 +48,95 @@ struct RecordStatsView: View {
         }
     }
     
-    init(gameStore: EnvironmentObject<GameStore>, shotsData: ShotsData) {
+    init(gameStore: EnvironmentObject<GameStore>, shotsData: ShotsData, popToSeasonsView: Binding<Bool>? = nil) {
         _gameStore = gameStore
         _shotsData = State(initialValue: shotsData)
         _pointsOn12Meter = State(initialValue: shotsData.shots)
         _selectedGoalieName = State(initialValue: shotsData.goalies.first ?? ShotsData.defaultGoalieName)
         loadPastView = true
         disable = true
+        self.popToSeasonsView = popToSeasonsView
     }
     
     var body: some View {
-        GeometryReader { proxy in
-            ScrollView(.vertical) {
-                VStack {
-                    GameTitleView(parent: self, geometry: proxy)
-                    GoalieSelectorView(
-                        shotsData: shotsData,
-                        selectedGoalieName: $selectedGoalieName,
-                        disableAddingGoalie: loadPastView,
-                        onGoaliesChanged: persistGoalieChange
-                    )
+        ZStack {
+            GeometryReader { proxy in
+                ScrollView(.vertical) {
                     VStack {
-                        ShotSelectorsView(parent: self, geometry: proxy)
-                        FieldView(parent: self, geometry: proxy)
-                        ScoringView(parent: self, geometry: proxy)
-                        GameButtonsView(parent: self, geometry: proxy)
+                        GameTitleView(parent: self, geometry: proxy)
+                        GoalieSelectorView(
+                            shotsData: shotsData,
+                            selectedGoalieName: $selectedGoalieName,
+                            disableAddingGoalie: loadPastView,
+                            onGoaliesChanged: persistGoalieChange
+                        )
+                        VStack {
+                            ShotSelectorsView(parent: self, geometry: proxy)
+                            FieldView(parent: self, geometry: proxy)
+                            ScoringView(parent: self, geometry: proxy)
+                            GameButtonsView(parent: self, geometry: proxy)
+                        }
+                        .disabled(disable)
+
+                        if loadPastView == true && shotsData.seasonName.isEmpty && gameStore.seasons.isEmpty == false {
+                            Spacer()
+                                .frame(height: proxy.size.height * 0.02)
+                            Menu {
+                                ForEach(gameStore.seasons, id: \.self) { season in
+                                    Button(season) {
+                                        addGameToSeason(season)
+                                    }
+                                }
+                            } label: {
+                                Text("Add Game to Season")
+                                    .foregroundStyle(.teal)
+                                    .font(.system(size: proxy.size.height * 0.0225))
+                                    .overlay(
+                                        RoundedRectangle(cornerRadius: proxy.size.width * 0.02)
+                                            .stroke(Color.gray, lineWidth: proxy.size.height * 0.004)
+                                            .frame(width: proxy.size.width * 0.45, height: proxy.size.height * 0.045)
+                                    )
+                            }
+                            Spacer()
+                                .frame(height: proxy.size.height * 0.02)
+                        }
                     }
-                    .disabled(disable)
+                    .navigationBarBackButtonHidden(loadPastView == false)
                 }
-                .navigationBarBackButtonHidden(true)
             }
+
+            if showSavePopup {
+                SaveGamePopupView(seasons: gameStore.seasons) { seasonName in
+                    showSavePopup = false
+                    shotsData.seasonName = seasonName
+                    let game = shotsData
+                    Task {
+                        do {
+                            try await gameStore.save(game: game)
+                        }
+                        catch {
+                            fatalError(error.localizedDescription)
+                        }
+                        presentationMode.wrappedValue.dismiss()
+                    }
+                }
+            }
+        }
+    }
+
+    func addGameToSeason(_ seasonName: String) {
+        shotsData.seasonName = seasonName
+        seasonAssignmentRefresh.toggle()
+        let game = shotsData
+        Task {
+            do {
+                try await gameStore.update(game: game)
+            }
+            catch {
+                // don't surface errors when assigning a season
+            }
+            popToSeasonsView?.wrappedValue = true
+            presentationMode.wrappedValue.dismiss()
         }
     }
 

--- a/GoalieStatsTracker/Views/SaveGamePopupView.swift
+++ b/GoalieStatsTracker/Views/SaveGamePopupView.swift
@@ -1,0 +1,96 @@
+//
+//  SaveGamePopupView.swift
+//  GoalieStatsTracker
+//
+
+import Foundation
+import SwiftUI
+
+struct SaveGamePopupView: View {
+
+    let seasons: [String]
+    let onConfirm: (String) -> Void
+
+    @State private var selectedSeason: String = ""
+    @State private var isCreatingNewSeason: Bool = false
+    @State private var newSeasonName: String = ""
+
+    var body: some View {
+        ZStack {
+            Color.black.opacity(0.4)
+                .ignoresSafeArea()
+
+            VStack(spacing: 0) {
+                VStack(spacing: 8) {
+                    Text("Game has been saved!")
+                        .font(.headline)
+                        .multilineTextAlignment(.center)
+                    Text("Go to Seasons to view your game")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                        .multilineTextAlignment(.center)
+
+                    if isCreatingNewSeason {
+                        TextField("Season name", text: $newSeasonName)
+                            .textFieldStyle(.roundedBorder)
+                            .padding(.top, 8)
+                    }
+                    else {
+                        Menu {
+                            ForEach(seasons, id: \.self) { season in
+                                Button(season) {
+                                    selectedSeason = season
+                                }
+                            }
+                            Button("Create New Season…") {
+                                isCreatingNewSeason = true
+                            }
+                        } label: {
+                            HStack {
+                                Text(selectedSeason.isEmpty ? "Select Season" : selectedSeason)
+                                Image(systemName: "chevron.up.chevron.down")
+                                    .font(.footnote)
+                            }
+                            .padding(.vertical, 6)
+                            .padding(.horizontal, 12)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 8)
+                                    .stroke(Color.gray, lineWidth: 1)
+                            )
+                        }
+                        .padding(.top, 8)
+                    }
+                }
+                .padding()
+
+                Divider()
+
+                Button(
+                    action: {
+                        let season = isCreatingNewSeason
+                            ? newSeasonName.trimmingCharacters(in: .whitespaces)
+                            : selectedSeason
+                        onConfirm(season)
+                    },
+                    label: {
+                        Text("Save Game")
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 12)
+                    }
+                )
+            }
+            .frame(maxWidth: 300)
+            .background(
+                RoundedRectangle(cornerRadius: 14)
+                    .fill(Color(UIColor.systemBackground))
+            )
+            .padding(40)
+        }
+    }
+}
+
+struct SaveGamePopupView_Previews: PreviewProvider {
+    static var previews: some View {
+        SaveGamePopupView(seasons: ["Spring 2026", "Fall 2025"], onConfirm: { _ in })
+    }
+}

--- a/GoalieStatsTracker/Views/SeasonsView.swift
+++ b/GoalieStatsTracker/Views/SeasonsView.swift
@@ -1,0 +1,100 @@
+//
+//  SeasonsView.swift
+//  GoalieStatsTracker
+//
+
+import Foundation
+import SwiftUI
+
+struct SeasonsView: View {
+
+    struct GoalieSeasonStat {
+        let goalieName: String
+        let savePercentage: Int
+    }
+
+    @EnvironmentObject var gameStore: GameStore
+
+    var body: some View {
+        GeometryReader { proxy in
+            List {
+                ForEach(gameStore.seasons, id: \.self) { season in
+                    NavigationLink {
+                        LoadPastView(seasonName: season)
+                    } label: {
+                        VStack(alignment: .leading) {
+                            Text(season)
+                                .font(.system(size: proxy.size.height * 0.02, weight: .semibold))
+                            ForEach(savePercentages(forSeason: season), id: \.goalieName) { stat in
+                                Spacer()
+                                    .frame(height: proxy.size.height * 0.0075)
+                                Text("\(stat.goalieName): \(stat.savePercentage)%")
+                                    .font(.system(size: proxy.size.height * 0.0175, weight: .light))
+                            }
+                        }
+                    }
+                }
+                .onDelete { indexes in
+                    Task {
+                        await deleteSeason(offsets: indexes)
+                    }
+                }
+                if gameStore.storage.contains(where: { $0.seasonName.isEmpty }) {
+                    NavigationLink {
+                        LoadPastView(seasonName: "")
+                    } label: {
+                        Text("No Season")
+                            .font(.system(size: proxy.size.height * 0.02, weight: .semibold))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+            .navigationTitle("Seasons")
+        }
+        .task {
+            do {
+                let _ = try await gameStore.load()
+            }
+            catch {}
+        }
+    }
+
+    func savePercentages(forSeason season: String) -> [GoalieSeasonStat] {
+        let seasonGames = gameStore.storage.filter { $0.seasonName == season }
+
+        var goalieNames: [String] = []
+        for game in seasonGames {
+            for shot in game.shots {
+                if goalieNames.contains(shot.goalieName) == false {
+                    goalieNames.append(shot.goalieName)
+                }
+            }
+        }
+
+        return goalieNames.map { goalie in
+            let percentages = seasonGames
+                .filter { $0.totalShots(forGoalie: goalie) > 0 }
+                .map { $0.savePercentage(forGoalie: goalie) }
+            let average = percentages.reduce(0, +) / percentages.count
+            return GoalieSeasonStat(goalieName: goalie, savePercentage: average)
+        }
+    }
+
+    func deleteSeason(offsets: IndexSet) async {
+        do {
+            let seasonsToDelete = offsets.map { gameStore.seasons[$0] }
+            for season in seasonsToDelete {
+                try await gameStore.removeSeason(named: season)
+            }
+        }
+        catch {
+            fatalError(error.localizedDescription)
+        }
+    }
+}
+
+struct SeasonsView_Previews: PreviewProvider {
+    static var previews: some View {
+        SeasonsView()
+    }
+}


### PR DESCRIPTION
- Store a season name on each game (ShotsData), backward compatible with previously saved games
- Save popup now lets the user pick an existing season or create a new one, and confirms with a Save Game button
- New SeasonsView lists all seasons with per-goalie average save percentages, plus a No Season row for unassigned games; seasons can be swipe-deleted (games are kept, label cleared)
- LoadPastView filters games by season, shows date and goalies per game, and fixes delete to map filtered rows to storage indexes
- Past games without a season get an Add Game to Season dropdown that assigns the game and returns to SeasonsView
- Season name shown under the date when viewing a past game