### PR TITLE
Fix cross-device shot rendering and deletion sync

### DIFF
--- a/GoalieStatsTracker/CloudGameStore.swift
+++ b/GoalieStatsTracker/CloudGameStore.swift
@@ -115,6 +115,20 @@ class CloudGameStore {
         return games
     }
 
+    /// Returns whether a game record still exists in iCloud. Uses a
+    /// strongly-consistent fetch by record ID so a recently-pushed record is
+    /// never mistaken for a deleted one — CKQuery results lag recent writes,
+    /// but record(for:) does not.
+    func gameExists(gameTime: TimeInterval) async throws -> Bool {
+        do {
+            _ = try await database.record(for: CloudGameStore.recordID(for: gameTime))
+            return true
+        }
+        catch let error as CKError where error.code == .unknownItem {
+            return false
+        }
+    }
+
     func deleteGame(gameTime: TimeInterval) async throws {
         do {
             try await database.deleteRecord(withID: CloudGameStore.recordID(for: gameTime))

--- a/GoalieStatsTracker/GameStore.swift
+++ b/GoalieStatsTracker/GameStore.swift
@@ -20,6 +20,9 @@ class GameStore: ObservableObject {
     private static let pendingCloudDeletesKey = "GameStore.pendingCloudDeletes"
     private static let seasonOrderKey = "GameStore.seasonOrder"
     private static let seasonsNeedsPushKey = "GameStore.seasonsNeedsPush"
+    // The season list as it last stood in iCloud. Acts as the common ancestor
+    // for a three-way merge so deletions can be told apart from additions.
+    private static let seasonsBaselineKey = "GameStore.seasonsBaseline"
 
     // The user-controlled ordering of seasons. This is the source of truth for
     // order and lets seasons exist before any game references them; names found
@@ -239,6 +242,32 @@ class GameStore: ObservableObject {
             synced.insert(cloudGame.gameTime)
             storageChanged = true
         }
+
+        // Reconcile deletions made on other devices: a game we previously synced
+        // that is now absent from the cloud was deleted elsewhere. Confirm each
+        // one with a strongly-consistent fetch before removing it locally, so a
+        // record that's merely lagging the query index isn't wrongly dropped.
+        let cloudGameTimes = Set(cloudGames.map { $0.gameTime })
+        let deletionCandidates = storage.filter {
+            synced.contains($0.gameTime)
+                && cloudGameTimes.contains($0.gameTime) == false
+                && pendingDeletes.contains($0.gameTime) == false
+        }
+        var remotelyDeleted: Set<TimeInterval> = []
+        for game in deletionCandidates {
+            if let stillExists = try? await cloudStore.gameExists(gameTime: game.gameTime),
+               stillExists == false {
+                remotelyDeleted.insert(game.gameTime)
+            }
+        }
+        if remotelyDeleted.isEmpty == false {
+            storage.removeAll { remotelyDeleted.contains($0.gameTime) }
+            for gameTime in remotelyDeleted {
+                synced.remove(gameTime)
+            }
+            storageChanged = true
+        }
+
         if storageChanged {
             storage.sort { $0.gameTime > $1.gameTime }
             if let data = try? JSONEncoder().encode(storage), let outfile = try? Self.fileURL() {
@@ -274,27 +303,46 @@ class GameStore: ObservableObject {
         }
     }
 
-    /// Reconciles the local season ordering with iCloud. When this device has
-    /// pending changes its order wins; otherwise the cloud order is adopted.
-    /// Either way seasons present on only one side are preserved (appended).
+    /// Reconciles the explicit season ordering with iCloud using a three-way
+    /// merge against the last-synced baseline, so a season deleted on one device
+    /// is removed everywhere instead of being resurrected by a plain union.
+    /// `seasonOrder` (not the derived `seasons`) is the unit of sync; seasons
+    /// that exist only because a game references them stay a local concern.
     private func syncSeasons() async {
         let cloudSeasons = (try? await cloudStore.fetchSeasons()) ?? nil
-        let localSeasons = seasons
+        let localSeasons = seasonOrder
 
         guard let cloudSeasons = cloudSeasons else {
-            // No cloud record yet; seed it from whatever this device has.
-            if localSeasons.isEmpty == false, await cloudStore.saveSeasons(localSeasons) {
+            // No cloud record yet; seed it from whatever this device has,
+            // including game-derived names so nothing is lost on first sync.
+            let seed = seasons
+            if seed.isEmpty == false, await cloudStore.saveSeasons(seed) {
                 clearSeasonsNeedsPush()
+                saveSeasonsBaseline(seed)
             }
             return
         }
 
         let preferLocalOrder = seasonsNeedsPush()
-        let merged = preferLocalOrder
-            ? mergeSeasons(primary: localSeasons, secondary: cloudSeasons)
-            : mergeSeasons(primary: cloudSeasons, secondary: localSeasons)
+        let merged: [String]
+        if let baseline = seasonsBaseline() {
+            merged = threeWayMergeSeasons(
+                baseline: baseline,
+                local: localSeasons,
+                cloud: cloudSeasons,
+                preferLocalOrder: preferLocalOrder
+            )
+        }
+        else {
+            // No baseline yet (first sync after upgrade): fall back to a union so
+            // we don't misread pre-existing seasons as deletions, then record a
+            // baseline for next time.
+            merged = preferLocalOrder
+                ? mergeSeasons(primary: localSeasons, secondary: cloudSeasons)
+                : mergeSeasons(primary: cloudSeasons, secondary: localSeasons)
+        }
 
-        if merged != seasons {
+        if merged != seasonOrder {
             seasonOrder = merged
             persistSeasonOrder()
         }
@@ -302,11 +350,39 @@ class GameStore: ObservableObject {
         if merged != cloudSeasons {
             if await cloudStore.saveSeasons(merged) {
                 clearSeasonsNeedsPush()
+                saveSeasonsBaseline(merged)
             }
         }
         else {
             clearSeasonsNeedsPush()
+            saveSeasonsBaseline(merged)
         }
+    }
+
+    /// Three-way merge of season lists. An entry present in the baseline is kept
+    /// only if it still survives on both sides; missing on either side means it
+    /// was deleted there. Entries absent from the baseline are additions and are
+    /// always kept. Order follows the side with pending changes.
+    private func threeWayMergeSeasons(baseline: [String], local: [String], cloud: [String], preferLocalOrder: Bool) -> [String] {
+        let baselineSet = Set(baseline)
+        let localSet = Set(local)
+        let cloudSet = Set(cloud)
+
+        func keep(_ season: String) -> Bool {
+            if baselineSet.contains(season) {
+                return localSet.contains(season) && cloudSet.contains(season)
+            }
+            return true
+        }
+
+        let primary = preferLocalOrder ? local : cloud
+        let secondary = preferLocalOrder ? cloud : local
+        var result: [String] = []
+        var seen: Set<String> = []
+        for season in primary + secondary where keep(season) && seen.insert(season).inserted {
+            result.append(season)
+        }
+        return result
     }
 
     /// Returns `primary` followed by any seasons that appear only in `secondary`.
@@ -373,6 +449,14 @@ class GameStore: ObservableObject {
 
     private func clearSeasonsNeedsPush() {
         UserDefaults.standard.set(false, forKey: GameStore.seasonsNeedsPushKey)
+    }
+
+    private func seasonsBaseline() -> [String]? {
+        UserDefaults.standard.stringArray(forKey: GameStore.seasonsBaselineKey)
+    }
+
+    private func saveSeasonsBaseline(_ seasons: [String]) {
+        UserDefaults.standard.set(seasons, forKey: GameStore.seasonsBaselineKey)
     }
 }
 

--- a/GoalieStatsTracker/ShotsData.swift
+++ b/GoalieStatsTracker/ShotsData.swift
@@ -25,6 +25,13 @@ class ShotsData: ObservableObject, Codable, Identifiable, Hashable {
     
     static let defaultGoalieName: String = "Me"
 
+    // Schema version for the persisted payload. Version 1 stores shot
+    // coordinates normalized as a fraction of the field width so they render
+    // correctly across devices with different screen sizes. Version 0 (absent)
+    // stored raw screen points captured on a single device.
+    static let currentSchemaVersion: Int = 1
+    var schemaVersion: Int = ShotsData.currentSchemaVersion
+
     @Published var runningScore: Float = 0
     @Published var totalShots: Int = 0
     @Published var saves: Int = 0
@@ -46,11 +53,12 @@ class ShotsData: ObservableObject, Codable, Identifiable, Hashable {
     }
     
     enum CodingKeys: CodingKey {
-        case runningScore, totalShots, saves, savePercentage, shots, gameName, gameTime, womensField, goalies, seasonName
+        case runningScore, totalShots, saves, savePercentage, shots, gameName, gameTime, womensField, goalies, seasonName, schemaVersion
     }
-    
+
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(schemaVersion, forKey: .schemaVersion)
         try container.encode(runningScore, forKey: .runningScore)
         try container.encode(totalShots, forKey: .totalShots)
         try container.encode(saves, forKey: .saves)
@@ -81,6 +89,8 @@ class ShotsData: ObservableObject, Codable, Identifiable, Hashable {
         }
         goalies = (try? container.decode([String].self, forKey: .goalies)) ?? [ShotsData.defaultGoalieName]
         seasonName = (try? container.decode(String.self, forKey: .seasonName)) ?? ""
+        // A payload without a version predates normalized coordinates.
+        schemaVersion = (try? container.decode(Int.self, forKey: .schemaVersion)) ?? 0
     }
     
     required init() {
@@ -107,6 +117,48 @@ class ShotsData: ObservableObject, Codable, Identifiable, Hashable {
         else {
             self.halfYCoordinate = menTransitionMark * ratio
         }
+    }
+
+    // Converts a screen-space tap point into a screen-size-agnostic coordinate
+    // stored as a fraction of the field width. Everything in the field view
+    // scales linearly with fieldWidth, so a single factor round-trips exactly.
+    func normalize(_ point: CGPoint) -> CGPoint {
+        guard fieldWidth > 0 else { return point }
+        return CGPoint(x: point.x / fieldWidth, y: point.y / fieldWidth)
+    }
+
+    // Reverses `normalize`, turning a stored fraction back into a point in the
+    // current field view's coordinate space.
+    func denormalize(_ point: CGPoint) -> CGPoint {
+        return CGPoint(x: point.x * fieldWidth, y: point.y * fieldWidth)
+    }
+
+    // The point at which a stored shot should be drawn. Version 1 shots are
+    // normalized and must be scaled to the current field; legacy (version 0)
+    // shots are still raw screen points and render as-is — which is correct on
+    // the device that recorded them, where they get upgraded on first view.
+    func displayCoordinate(for shot: Shot) -> CGPoint {
+        if schemaVersion >= ShotsData.currentSchemaVersion {
+            return denormalize(shot.coordinate)
+        }
+        return shot.coordinate
+    }
+
+    // Upgrades a legacy game in place by normalizing its raw shot coordinates
+    // using the current fieldWidth. This is exact when the upgrade happens on a
+    // device whose field width matches the one used to record the game.
+    // Returns whether anything changed so callers can persist the upgrade.
+    func migrateCoordinatesIfNeeded() -> Bool {
+        guard schemaVersion < ShotsData.currentSchemaVersion, fieldWidth > 0 else {
+            return false
+        }
+        shots = shots.map { shot in
+            var upgraded = shot
+            upgraded.coordinate = normalize(shot.coordinate)
+            return upgraded
+        }
+        schemaVersion = ShotsData.currentSchemaVersion
+        return true
     }
     
     struct Shot: Codable, Hashable {
@@ -245,8 +297,9 @@ class ShotsData: ObservableObject, Codable, Identifiable, Hashable {
             return nil
         }
         let grid = whichGrid(coordinate: location)
-        print("girf: \(grid)")
-        let shot = Shot(wasItAGoal: goal, wasItEightMeter: eightMeter, gridItCameFrom: grid, coordinate: location, goalieName: goalieName)
+        // Bounds and grid are decided in screen space above; the coordinate is
+        // persisted normalized so it renders correctly on any screen size.
+        let shot = Shot(wasItAGoal: goal, wasItEightMeter: eightMeter, gridItCameFrom: grid, coordinate: normalize(location), goalieName: goalieName)
         runningScore += shot.calculateScore()
         totalShots += 1
         

--- a/GoalieStatsTracker/Views/FieldView.swift
+++ b/GoalieStatsTracker/Views/FieldView.swift
@@ -48,7 +48,7 @@ struct FieldView: View {
                 .scaledToFit()
                 .frame(maxWidth: .infinity, alignment: .bottomLeading)
             ForEach(_parent.pointsOn12Meter.filter { $0.goalieName == _parent.selectedGoalieName }, id: \.self) { shot in
-                ClickedCircle(currentLocation: shot.coordinate, circleColor: circleColor(wasItAGoal: shot.wasItAGoal, wasItA8Meter: shot.wasItEightMeter), geometry: _geometry)
+                ClickedCircle(currentLocation: _parent.shotsData.displayCoordinate(for: shot), circleColor: circleColor(wasItAGoal: shot.wasItAGoal, wasItA8Meter: shot.wasItEightMeter), geometry: _geometry)
             }
             if _parent.loadPastView == false {
                 Button(
@@ -83,6 +83,11 @@ struct FieldView: View {
         .fixedSize(horizontal: false, vertical: true)
         .contentShape(Rectangle())
         .gesture(draw12MeterCircle)
+        .onAppear {
+            // fieldWidth was set in init, so a legacy game can now be upgraded
+            // to normalized coordinates using this device's field width.
+            _parent.migrateLegacyCoordinatesIfNeeded()
+        }
 
         Divider()
     }

--- a/GoalieStatsTracker/Views/RecordStatsView.swift
+++ b/GoalieStatsTracker/Views/RecordStatsView.swift
@@ -185,6 +185,28 @@ struct RecordStatsView: View {
         }
     }
 
+    // Upgrades a legacy (schema v0) game to normalized coordinates once the
+    // field width is known, then persists the upgrade. `pointsOn12Meter` is the
+    // array actually rendered, so it must be re-synced from the upgraded shots.
+    func migrateLegacyCoordinatesIfNeeded() {
+        guard shotsData.migrateCoordinatesIfNeeded() else { return }
+        pointsOn12Meter = shotsData.shots
+        let game = shotsData
+        let isPastGame = loadPastView
+        Task {
+            do {
+                if isPastGame {
+                    try await gameStore.update(game: game)
+                } else {
+                    try await gameStore.saveOngoingGame(game: game)
+                }
+            }
+            catch {
+                // don't surface errors during a one-time upgrade
+            }
+        }
+    }
+
     func persistGoalieChange() {
         pointsOn12Meter = shotsData.shots
         let game = shotsData


### PR DESCRIPTION
## Summary

Two iCloud-sync correctness fixes surfaced now that the same game can be viewed on multiple devices.

### 1. Screen-size-agnostic shot coordinates
`Shot.coordinate` was stored as raw screen points tied to the field width at record time, so games synced via iCloud rendered shots in the wrong place on a device with a different screen size.

- Coordinates are now persisted **normalized as a fraction of the field width** and scaled back to the current field on display. Every spatial value in the field view scales linearly with `fieldWidth`, so a single factor round-trips exactly.
- Added a `schemaVersion` to the payload. Legacy (v0) games are upgraded in place the first time they're viewed — using the field width then available — and re-persisted (and re-pushed to iCloud) as v1. This is exact when the upgrade happens on the device that recorded the game (the normal case).
- Removed a leftover debug `print`.

### 2. Deletions now propagate across devices
Sync was additive-only: games and seasons deleted on one device reappeared on others.

- **Games:** after pulling cloud games, reconcile deletions by removing any locally-synced game now absent from the cloud, confirmed with a strongly-consistent `record(for:)` fetch so a record merely lagging the query index isn't wrongly dropped.
- **Seasons:** replaced the union merge (which can only grow) with a **three-way merge against a stored last-synced baseline**, syncing the explicit `seasonOrder` so a deleted season isn't resurrected by union or by a still-referencing local game. Installs with no baseline fall back to the old union for one cycle, then record a baseline.

## Testing
- `xcodebuild` (Debug, generic iOS) succeeds.
- Manually verified by the author on-device for both coordinate rendering and game/season deletion propagation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
